### PR TITLE
Clarify the main purpose of the os argument

### DIFF
--- a/R/data.r
+++ b/R/data.r
@@ -25,6 +25,12 @@
 #' Arguably plugins such as R packages should go into the user configuration directory and deleting
 #' this directory should return the application to a default settings.
 #'
+#' The \code{os} parameter allows the calculation of directories based on a
+#' convention other than the current operating system. This feature is designed
+#' with package testing in mind and is \emph{not} recommended for end users. One
+#' possible exception is that some users on "mac" might wish to use the "unix" 
+#' XDG convention.
+#' 
 #' @param appname is the name of application. If NULL, just the system
 #'     directory is returned.
 #' @param appauthor (only required and used on Windows) is the name of the
@@ -41,9 +47,12 @@
 #'     sync'd on login. See
 #'     \url{http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx}
 #'     for a discussion of issues.
-#' @param os Operating system which we should create directory for, 
-#'     if NULL (the default) will compute the operating system using R's built in variables/functions.  
-#'     Values are "win", "mac", "unix".
+#' @param os Operating system whose conventions are used to construct the
+#'     requested directory. Possible values are "win", "mac", "unix". If NULL
+#'     (the default) then the convention of the current operating system
+#'     (as determined by rappdirs:::get_os) will be used. This argument is
+#'     unlikely to find much use outside package testing (see details section of
+#'     \code{\link{user_data_dir}}).
 #' @param expand If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.  
 #'      See \code{\link{R_LIBS}} for list of all possibly specifiers.
 #' 

--- a/man/app_dir.Rd
+++ b/man/app_dir.Rd
@@ -23,9 +23,12 @@ is not NULL.}
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}
 
-\item{os}{Operating system which we should create directory for,
-if NULL (the default) will compute the operating system using R's built in variables/functions.
-Values are "win", "mac", "unix".}
+\item{os}{Operating system whose conventions are used to construct the
+requested directory. Possible values are "win", "mac", "unix". If NULL
+(the default) then the convention of the current operating system
+(as determined by rappdirs:::get_os) will be used. This argument is
+unlikely to find much use outside package testing (see details section of
+\code{\link{user_data_dir}}).}
 }
 \description{
 Has methods:

--- a/man/site_data_dir.Rd
+++ b/man/site_data_dir.Rd
@@ -31,9 +31,12 @@ is not NULL.}
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}
 
-\item{os}{Operating system which we should create directory for,
-if NULL (the default) will compute the operating system using R's built in variables/functions.
-Values are "win", "mac", "unix".}
+\item{os}{Operating system whose conventions are used to construct the
+requested directory. Possible values are "win", "mac", "unix". If NULL
+(the default) then the convention of the current operating system
+(as determined by rappdirs:::get_os) will be used. This argument is
+unlikely to find much use outside package testing (see details section of
+\code{\link{user_data_dir}}).}
 }
 \description{
 \code{site_data_dir} returns full path to the user-shared data dir for this application.

--- a/man/user_cache_dir.Rd
+++ b/man/user_cache_dir.Rd
@@ -26,9 +26,12 @@ is not NULL.}
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}
 
-\item{os}{Operating system which we should create directory for,
-if NULL (the default) will compute the operating system using R's built in variables/functions.
-Values are "win", "mac", "unix".}
+\item{os}{Operating system whose conventions are used to construct the
+requested directory. Possible values are "win", "mac", "unix". If NULL
+(the default) then the convention of the current operating system
+(as determined by rappdirs:::get_os) will be used. This argument is
+unlikely to find much use outside package testing (see details section of
+\code{\link{user_data_dir}}).}
 }
 \description{
 Typical user cache directories are:

--- a/man/user_data_dir.Rd
+++ b/man/user_data_dir.Rd
@@ -31,9 +31,12 @@ sync'd on login. See
 \url{http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx}
 for a discussion of issues.}
 
-\item{os}{Operating system which we should create directory for,
-if NULL (the default) will compute the operating system using R's built in variables/functions.
-Values are "win", "mac", "unix".}
+\item{os}{Operating system whose conventions are used to construct the
+requested directory. Possible values are "win", "mac", "unix". If NULL
+(the default) then the convention of the current operating system
+(as determined by rappdirs:::get_os) will be used. This argument is
+unlikely to find much use outside package testing (see details section of
+\code{\link{user_data_dir}}).}
 
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}
@@ -64,6 +67,12 @@ See for example \url{http://ploum.net/184-cleaning-user-preferences-keeping-user
 or \url{http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html} for more information.
 Arguably plugins such as R packages should go into the user configuration directory and deleting
 this directory should return the application to a default settings.
+
+The \code{os} parameter allows the calculation of directories based on a
+convention other than the current operating system. This feature is designed
+with package testing in mind and is \emph{not} recommended for end users. One
+possible exception is that some users on "mac" might wish to use the "unix"
+XDG convention.
 }
 \examples{
 user_data_dir("rappdirs")

--- a/man/user_log_dir.Rd
+++ b/man/user_log_dir.Rd
@@ -27,9 +27,12 @@ is not NULL.}
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}
 
-\item{os}{Operating system which we should create directory for,
-if NULL (the default) will compute the operating system using R's built in variables/functions.
-Values are "win", "mac", "unix".}
+\item{os}{Operating system whose conventions are used to construct the
+requested directory. Possible values are "win", "mac", "unix". If NULL
+(the default) then the convention of the current operating system
+(as determined by rappdirs:::get_os) will be used. This argument is
+unlikely to find much use outside package testing (see details section of
+\code{\link{user_data_dir}}).}
 }
 \description{
 Typical user cache directories are:


### PR DESCRIPTION
This just adds a bit of documentation to indicate that the os argument
is primarily intended for testing rather than end users.

this could be used to close out #4 
