### PR TITLE
docs: caveats section notes race conditions

### DIFF
--- a/R/rappdirs-package.r
+++ b/R/rappdirs-package.r
@@ -3,19 +3,6 @@
 #' @description rappdirs solves the problem of where to save persistent data 
 #'   outside of the R library or the R per-session \code{\link{tempdir}}.
 #'   
-#'   Note that the
-#'   \href{http://cran.r-project.org/web/packages/policies.html}{CRAN Policies} 
-#'   have the following to say about storage of data by packages:
-#'   
-#'   - Packages should not write in the users' home filespace, nor anywhere else
-#'   on the file system apart from the R session's temporary directory (or 
-#'   during installation in the location pointed to by TMPDIR: and such usage 
-#'   should be cleaned up). Installing into the system's R installation (e.g., 
-#'   scripts to its bin directory) is not allowed.
-#'   
-#'   Limited exceptions may be allowed in interactive sessions if the package 
-#'   obtains confirmation from the user.
-#'   
 #' @section main functions: \itemize{
 #'   
 #'   \item user data dir (\code{user_data_dir})
@@ -33,6 +20,28 @@
 #' @section single entry function:
 #'   
 #'   The \code{app_dir} provides a convenient single entry point.
+#'   
+#' @section Caveats: Note that if you use rappdir's \code{\link{user_data_dir}} 
+#'   and friends to define a storage location for files you must be aware of 
+#'   \href{http://en.wikipedia.org/wiki/Race_condition}{race conditions} when 
+#'   more than one R process tries to create/write files in this directory. This
+#'   is in contrast to using the \code{\link{tempdir}}, \code{\link{tempfile}}
+#'   base functions which should be unique for each R process. In general the
+#'   directories provided by rappdirs are most suitable for storing data that is
+#'   rarely written but might need to be shared across R sessions.
+#'   
+#'   Note also that the 
+#'   \href{http://cran.r-project.org/web/packages/policies.html}{CRAN Policies} 
+#'   have the following to say about storage of data by packages:
+#'   
+#'   - Packages should not write in the users' home filespace, nor anywhere else
+#'   on the file system apart from the R session's temporary directory (or 
+#'   during installation in the location pointed to by TMPDIR: and such usage 
+#'   should be cleaned up). Installing into the system's R installation (e.g., 
+#'   scripts to its bin directory) is not allowed.
+#'   
+#'   Limited exceptions may be allowed in interactive sessions if the package 
+#'   obtains confirmation from the user.
 #'   
 #' @examples
 #' dirs <- app_dir("SuperApp", "Acme")

--- a/man/rappdirs-package.Rd
+++ b/man/rappdirs-package.Rd
@@ -7,19 +7,6 @@
 \description{
 rappdirs solves the problem of where to save persistent data
   outside of the R library or the R per-session \code{\link{tempdir}}.
-
-  Note that the
-  \href{http://cran.r-project.org/web/packages/policies.html}{CRAN Policies}
-  have the following to say about storage of data by packages:
-
-  - Packages should not write in the users' home filespace, nor anywhere else
-  on the file system apart from the R session's temporary directory (or
-  during installation in the location pointed to by TMPDIR: and such usage
-  should be cleaned up). Installing into the system's R installation (e.g.,
-  scripts to its bin directory) is not allowed.
-
-  Limited exceptions may be allowed in interactive sessions if the package
-  obtains confirmation from the user.
 }
 \section{main functions}{
  \itemize{
@@ -41,6 +28,30 @@ rappdirs solves the problem of where to save persistent data
 
 
   The \code{app_dir} provides a convenient single entry point.
+}
+
+\section{Caveats}{
+ Note that if you use rappdir's \code{\link{user_data_dir}}
+  and friends to define a storage location for files you must be aware of
+  \href{http://en.wikipedia.org/wiki/Race_condition}{race conditions} when
+  more than one R process tries to create/write files in this directory. This
+  is in contrast to using the \code{\link{tempdir}}, \code{\link{tempfile}}
+  base functions which should be unique for each R process. In general the
+  directories provided by rappdirs are most suitable for storing data that is
+  rarely written but might need to be shared across R sessions.
+
+  Note also that the
+  \href{http://cran.r-project.org/web/packages/policies.html}{CRAN Policies}
+  have the following to say about storage of data by packages:
+
+  - Packages should not write in the users' home filespace, nor anywhere else
+  on the file system apart from the R session's temporary directory (or
+  during installation in the location pointed to by TMPDIR: and such usage
+  should be cleaned up). Installing into the system's R installation (e.g.,
+  scripts to its bin directory) is not allowed.
+
+  Limited exceptions may be allowed in interactive sessions if the package
+  obtains confirmation from the user.
 }
 \examples{
 dirs <- app_dir("SuperApp", "Acme")


### PR DESCRIPTION
- also move details re CRAN policies out of description and into a new
  caveats section lower down.
- this is probably a desirable addition before/in addition to merging hadley#14
