### PR TITLE
Enable AppVeyor testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 ^cran-comments\.md$
+^appveyor\.yml$

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/hadley/rappdirs.svg)](https://travis-ci.org/hadley/rappdirs)
+[![Travis-CI build Status](https://travis-ci.org/hadley/rappdirs.svg)](https://travis-ci.org/hadley/rappdirs) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/esqelnh58yryf21b/branch/master)](https://ci.appveyor.com/project/hadley/rappdirs/branch/master)
 
 `rappdirs` is a port of [appdirs](https://github.com/ActiveState/appdirs) to R.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - travis-tool.sh dump_logs


### PR DESCRIPTION
[AppVeyor](http://appveyor.com) is a Windows-based CI system much like Travis CI, and also free for open-source projects. I have prepared [a wrapper around r-travis](/krlmlr/r-appveyor) so that AppVeyor can be used to test R packages (and also later deploy them in binary form). It's work in progress, but I think the format of the `appveyor.yml` configuration file is more or less stable.

Example: [Test output](https://ci.appveyor.com/project/krlmlr/rappdirs/build/1.0.77) for this branch.

This pull request installs the AppVeyor configuration file, asks to ignore it for building the R package, and adds a badge to `README.md`. The URL for the badge's image seems to contain some project-specific code, so it should be adapted to that shown in https://ci.appveyor.com/project/hadley/rappdirs/settings/badges (after registering the project).
