### PR TITLE
Fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ some example output
 
 On Mac OS X:
 
-    library(appdirs)
+    library(rappdirs)
     appname <- "SuperApp"
     appauthor <- "Acme"
     user_config_dir(appname, appauthor)
@@ -70,7 +70,7 @@ On Mac OS X:
 
 On Windows 7:
 
-    library(appdirs)
+    library(rappdirs)
     appname <- "SuperApp"
     appauthor <- "Acme"
     user_config_dir(appname, appauthor)
@@ -86,7 +86,7 @@ On Windows 7:
 
 On Linux:
 
-    library(appdirs)
+    library(rappdirs)
     appname <- "SuperApp"
     appauthor <- "Acme"
     user_config_dir(appname, appauthor)
@@ -103,7 +103,7 @@ On Linux:
 `app_dir` for convenience
 =========================
 
-    library(appdirs)
+    library(rappdirs)
     dirs <- app_dir("SuperApp", "Acme")
     dirs$config()
     # "/Users/trentm/Library/Application Support/SuperApp"
@@ -123,7 +123,7 @@ If you have multiple versions of your app in use that you want to be
 able to run side-by-side, then you may want version-isolation for these
 dirs:
 
-    library(appdirs)
+    library(rappdirs)
     dirs <- app_dir("SuperApp", "Acme", version = "1.0")
     dirs$data()
     # "/Users/trentm/Library/Application Support/SuperApp/1.0"


### PR DESCRIPTION
It seems like the package name in README was not updated when porting?